### PR TITLE
Add 'version' command and bump to 0.0.43

### DIFF
--- a/.dart_tool/package_graph.json
+++ b/.dart_tool/package_graph.json
@@ -5,7 +5,7 @@
   "packages": [
     {
       "name": "shellforge",
-      "version": "0.0.42",
+      "version": "0.0.43",
       "dependencies": [
         "args",
         "path"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.0.43
+- Versioning call fixed.
+
+## 0.0.42
+- Fixes to pathing causing unexpected behavior
+
 ## 0.0.41
 
 - Initial Dart port of ShellForge

--- a/bin/forge.dart
+++ b/bin/forge.dart
@@ -20,7 +20,8 @@ void main(List<String> arguments) async {
   parser.addCommand('default');
   parser.addCommand('config');
   final newsCmd = parser.addCommand('news');
-  parser.addCommand('help');
+  parser.addCommand('version');
+
 
   runCmd.allowsAnything;
 
@@ -133,6 +134,9 @@ void main(List<String> arguments) async {
       break;
     case 'help':
       _printUsage();
+      break;
+    case 'version':
+      await printVersion();
       break;
     default:
       _printUsage();

--- a/lib/src/commands.dart
+++ b/lib/src/commands.dart
@@ -586,3 +586,7 @@ Future<void> viewConfig() async {
   final config = await loadConfig();
   print(config);
 }
+
+Future<void> printVersion() async {
+  print('ShellForge CLI version: $currentVersion');
+}

--- a/lib/src/config.dart
+++ b/lib/src/config.dart
@@ -4,7 +4,7 @@ import 'package:path/path.dart' as p;
 
 import 'constants.dart';
 
-const String currentVersion = '0.0.41';
+const String currentVersion = 'ShellForge CLI v0.0.43';
 
 final Map<String, dynamic> defaultConfig = {
   ConfigKey.announcements: [

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: shellforge
 description: A workflow CLI to create, manage, and run reusable command sequences across Bash, Zsh, PowerShell, and CMD.
-version: 0.0.42
+version: 0.0.43
 homepage: https://github.com/BaerBonesTechnology/shellforge
 
 environment:


### PR DESCRIPTION
Register a new 'version' CLI command and implement printVersion to display the current version. Handle the command in bin/forge.dart's main switch. Bump package version to 0.0.43 in pubspec.yaml and .dart_tool/package_graph.json, and add a 0.0.43 entry to CHANGELOG.md. Update the currentVersion constant in lib/src/config.dart to 'ShellForge CLI v0.0.43'.